### PR TITLE
link all'albo pretorio del Comune di Crema

### DIFF
--- a/content/comune/crema.md
+++ b/content/comune/crema.md
@@ -1,7 +1,7 @@
 ---
 title: Crema
 tags: []
-original: http://crema.trasparenza-valutazione-merito.it/web/trasparenza/papca-ap/-/papca/igrid/1489180872/1489180071
+original: http://crema.trasparenza-valutazione-merito.it/web/trasparenza/albo-pretorio
 rss: https://script.googleusercontent.com/macros/echo?user_content_key=nocCnBKmQCK_GVB8V803X8jOtqsOM6aPAEgtva-ffQT96Lcj_m7qLPyQmke-wt5L55njDP3MkV1wj12jZnIwN3Nz5ixemA3xm5_BxDlH2jW0nuo2oDemN9CCS2h10ox_1xSncGQajx_ryfhECjZEnPlcxsZeAlbjZ9bpyoFG87FSH54-yXa7sv0elf_nGs_ewtHBnTAr6C28mzDTCqnGIg&lib=MwTtM1fYkupkTduWF1fAPjX_8p-fAkEuh&fbclid=IwAR15q6XJ00Qf9ev93L96ecSNECdZLnuzsoHtyqB71Anr1IOA8tpPpTPoNk4
 twitter: 
 facebook: 


### PR DESCRIPTION
il link esatto all'Albo Pretorio di Crema è http://crema.trasparenza-valutazione-merito.it/web/trasparenza/albo-pretorio. Quello presente nell'albopop è simile ma non esattamente lo stesso. errore mio.